### PR TITLE
feat: ランダムに猫を表示するページを実装

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,0 +1,3 @@
+.catImageContainer {
+  margin-top: 8px;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps, NextPage } from "next";
 import { useState } from "react";
+import styles from "./index.module.css";
 
 interface SearchCatImage {
   breeds: string[];
@@ -32,7 +33,7 @@ const IndexPage: NextPage<IndexPageProps> = ({ initialCatImageUrl }) => {
   return (
     <div>
       <button onClick={handleClick}>きょうのにゃんこ🐱</button>
-      <div style={{ marginTop: 10 }}>
+      <div className={styles.catImageContainer}>
         <img src={catImageUrl} width={500} height="auto" />
       </div>
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,53 @@
+import { GetServerSideProps, NextPage } from "next";
+import { useState } from "react";
+
+interface SearchCatImage {
+  breeds: string[];
+  id: string;
+  url: string;
+  width: number;
+  height: number;
+}
+
+type SearchCatImageResponse = SearchCatImage[];
+
+const fetchCatImage = async (): Promise<SearchCatImage> => {
+  const res = await fetch("https://api.thecatapi.com/v1/images/search");
+  const result = (await res.json()) as SearchCatImageResponse;
+  return result[0];
+};
+
+interface IndexPageProps {
+  initialCatImageUrl: string;
+}
+
+const IndexPage: NextPage<IndexPageProps> = ({ initialCatImageUrl }) => {
+  const [catImageUrl, setCatImageUrl] = useState(initialCatImageUrl);
+
+  const handleClick = async () => {
+    const image = await fetchCatImage();
+    setCatImageUrl(image.url);
+  };
+
+  return (
+    <div>
+      <button onClick={handleClick}>きょうのにゃんこ🐱</button>
+      <div style={{ marginTop: 10 }}>
+        <img src={catImageUrl} width={500} height="auto" />
+      </div>
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<
+  IndexPageProps
+> = async () => {
+  const catImage = await fetchCatImage();
+  return {
+    props: {
+      initialCatImageUrl: catImage.url,
+    },
+  };
+};
+
+export default IndexPage;


### PR DESCRIPTION
## 要件
- ページ読み込み時にランダムな猫画像を表示する
- ボタンをクリックして猫の画像をランダムに変更される

## 補足
### next/imageについて
Next.jsの話なので画像の表示には `next/image` を使おうと思いましたが、画像のアスペクト比がバラバラの場合だと扱いにくい部分もあるので使うのは止めています。

↓のように書けば普通に使うことは可能です。🙆🏻‍♂️

```tsx
<div style={{position: 'relative', width: 500, height: 500}}>
  <Image src={catImageUrl} layout="fill" objectFit="contain" />
</div>
```